### PR TITLE
Use (row, col) coordinates instead of (col, row)

### DIFF
--- a/Assets/MindsweeperPicross.unity
+++ b/Assets/MindsweeperPicross.unity
@@ -685,7 +685,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1531531368}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f5809556c58f42b43942fe1a1aeef59a, type: 3}
+  m_Script: {fileID: 11500000, guid: 15aed0c2e0989c64bad4b700f65b0478, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   infoButton: {fileID: 1531531370}

--- a/Assets/MindsweeperPicross.unity
+++ b/Assets/MindsweeperPicross.unity
@@ -786,6 +786,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c7a38d91b3abd174d8df2fcec6e79348, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  offsetI: 15
+  offsetJ: 5
   cell1: {fileID: 11400000, guid: 8a5f04c131f18644f8c3b4bbde576405, type: 2}
   cell2: {fileID: 11400000, guid: b5c7e2773becfb5489a529984c96efaa, type: 2}
   cell3: {fileID: 11400000, guid: e8f132b7d086e75499c2b760b942781d, type: 2}

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -6,8 +6,8 @@ using UnityEngine.Tilemaps;
 // Inherits from MonoBehaviour since it uses a Tilemap
 public class Board : MonoBehaviour
 {
-    int xOffset = 8;
-    int yOffset = 15;
+    public int offsetI;
+    public int offsetJ;
 
     public Tilemap tilemap
     {
@@ -46,52 +46,47 @@ public class Board : MonoBehaviour
     public Tile square15;
     public Tile square16;
 
-
     private void Awake()
     {
         tilemap = GetComponent<Tilemap>();
     }
 
-
     // Converts coordinates on the board to a cell position on tilemap.
-    public Vector3Int CoordToCell(int i, int j) {
-        return new Vector3Int(i + xOffset, yOffset - j, 0);
+    public Vector3Int CoordToCell(int i, int j)
+    {
+        return new Vector3Int(j + offsetJ, -i + offsetI, 0);
     }
-
 
     // Converts a cell position on tilemap to coordinates on the board.
-    public (int, int) CellToCoord(Vector3Int vec) {
-        return (vec.x - xOffset, -vec.y + yOffset);
+    public (int, int) CellToCoord(Vector3Int vec)
+    {
+        return (-vec.y + offsetI, vec.x - offsetJ);
     }
-
 
     // Converts a screen position wrt the main camera (e.g. Input.mousePosition)
     // to coordinates on the board.
-    public (int, int) ScreenToCoord(Vector3 vec) {
+    public (int, int) ScreenToCoord(Vector3 vec)
+    {
         Vector3 worldPoint = Camera.main.ScreenToWorldPoint(vec);
         Vector3Int cell = tilemap.WorldToCell(worldPoint);
         return CellToCoord(cell);
     }
 
-
-    /* All draw methods are given (i,j) coordinates relative to
-    only the Minesweeper grid (clickable cells) i.e. the top-left cell
-    is at (0,0) and a potential Picross square to the
-    left of it is at (-1,0) */
-
+    // All draw methods are given (i,j) coordinates relative to
+    // only the Minesweeper grid (clickable cells) i.e. the top-left cell
+    // is at (0,0) and a potential Picross square to the
+    // left of it is at (-1,0)
     public void drawSquare(Square square, int i, int j)
     {
         Vector3Int pos = CoordToCell(i, j);
         tilemap.SetTile(pos, squareTile(square));
     }
 
-
     public void drawCell(Cell cell, int i, int j)
     {
         Vector3Int pos = CoordToCell(i, j);
         tilemap.SetTile(pos, cellTile(cell));
     }
-
 
     private Tile squareTile(Square square)
     {
@@ -116,7 +111,6 @@ public class Board : MonoBehaviour
             default: return null;
         }
     }
-
 
     private Tile cellTile(Cell cell)
     {

--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -1,11 +1,7 @@
-using UnityEngine;
-
-// Inherits from MonoBehaviour - done for all classes in Unity
-public class Cell 
+public class Cell
 {
     // An integer of 0 represents an empty cell, -1 represents a mine, 9 represents a ?
     public int number;
     public bool revealed;
     public bool flagged;
-    
 }

--- a/Assets/Scripts/Info.cs
+++ b/Assets/Scripts/Info.cs
@@ -6,7 +6,6 @@ public class Info : MonoBehaviour
     public Button infoButton;
     public GameObject howToPlayText, howToPlayBackground;
 
-
     void Start()
     {
         infoButton.onClick.AddListener(() =>

--- a/Assets/Scripts/Info.cs.meta
+++ b/Assets/Scripts/Info.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f5809556c58f42b43942fe1a1aeef59a
+guid: 15aed0c2e0989c64bad4b700f65b0478
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/MainGame.cs
+++ b/Assets/Scripts/MainGame.cs
@@ -17,72 +17,63 @@ public class MainGame : MonoBehaviour
     private int[] picrossRows;
     private int[] picrossColumns;
 
-
-
     private void Awake()
     {
         board = GetComponentInChildren<Board>();
     }
-
 
     private void Start()
     {
         NewGame();
     }
 
-
     //generates new game (need to modify to start new game on user input later)
     private void NewGame()
     {
         //new game has initial game state
-        state = new Cell[width, height];
+        state = new Cell[height, width];
         MakeCells();
         MakeMines();
         NumberCells();
         MakeSquares();
 
-        for (int i = 0; i < width; i++)
+        for (int i = 0; i < height; i++)
         {
-            for (int j = 0; j < height; j++)
+            for (int j = 0; j < width; j++)
             {
                 board.drawCell(state[i, j], i, j);
             }
         }
     }
 
-
-
-
     //INITIAL SET UP =====================================================================================
 
-    private void MakeMines(){
+    private void MakeMines()
+    {
         //Iterates through the number of mines required (set to 50 by default)
-        for (int i = 0; i < mineNum; i++){
-            int x = 0;
-            int y = 0;
-            bool isMine = true;
-            while (isMine){
-                //Mines can be anywhere ranging from (0,0) to (width-1, height-1)
-                x = Random.Range(0, width);
-                y = Random.Range(0,height);
+        for (int iter = 0; iter < mineNum; iter++)
+        {
+            int i;
+            int j;
+            do
+            {
+                //Mines can be anywhere ranging from (0,0) to (height-1, width-1)
+                i = Random.Range(0, height);
+                j = Random.Range(0, width);
                 //This is to avoid generating a mine in the same position more than once. This ensures we have exactly 50 mines
-                if (!(state[x,y].number == -1)){
-                    isMine = false;
-                }
-            }
+            } while (state[i, j].number == -1);
 
             //sets cell to -1, allows board to draw the correct cell type (nuke-y)
-            state[x,y].number = -1;
+            state[i, j].number = -1;
         }
     }
 
-
-
-    private void MakeSquares(){
+    private void MakeSquares()
+    {
         //generates a random number between 2 and just below half of the respective dimension
         //This determines the number of the picross rows and columns
-        int rows = Random.Range(2,(height/2)-2);
-        int columns = Random.Range(2,(width/2)-2);
+        int rows = Random.Range(2, (height / 2) - 2);
+        int columns = Random.Range(2, (width / 2) - 2);
 
         picrossRows = new int[rows];
         picrossColumns = new int[columns];
@@ -91,144 +82,151 @@ public class MainGame : MonoBehaviour
         //The number of rows and columns does not exceed the numbers generated above.
         var picrossRowsSet = new HashSet<int>();
         var picrossColumnsSet = new HashSet<int>();
-        while (picrossRowsSet.Count < rows) {
+        while (picrossRowsSet.Count < rows)
+        {
             picrossRowsSet.Add(Random.Range(0, height));
         }
-        while (picrossColumnsSet.Count < columns) {
+        while (picrossColumnsSet.Count < columns)
+        {
             picrossColumnsSet.Add(Random.Range(0, width));
         }
         picrossRowsSet.CopyTo(picrossRows);
         picrossColumnsSet.CopyTo(picrossColumns);
 
-
-        foreach (int row in picrossRows){
+        foreach (int i in picrossRows)
+        {
             int pos = -1; //initialise position of picross squares. Must be to the left of the minesweeper grid
             int picrossSquare = 0; //initialise length of first maximal consecutive non-nukey cells to 0
-            int x = height-1; // to fill in picross squares from right to left we count the cells from right to left
 
-            while (x >= 0){
-                if (!(state[x,row].number == -1)){//if a cell is not a mine, set it to ? and increase our count of consecutive non-mines by 1
-                    state[x,row].number = 9;
-                    picrossSquare ++;
-                }else{//otherwise reset count to 0 and move to the next picross square position, so if (-1,row) is filled in, (-2,row) will be next ...
-                    if (picrossSquare != 0){
-                        board.drawSquare(new Square(picrossSquare),pos,row);
-                        pos --;
+            // to fill in picross squares from right to left we count the cells from right to left
+            for (int j = width - 1; j >= 0; j--)
+            {
+                if (state[i, j].number != -1)
+                {//if a cell is not a mine, set it to ? and increase our count of consecutive non-mines by 1
+                    state[i, j].number = 9;
+                    picrossSquare++;
+                }
+                else
+                {//otherwise reset count to 0 and move to the next picross square position, so if (i,-1) is filled in, (i,-2) will be next ...
+                    if (picrossSquare != 0)
+                    {
+                        board.drawSquare(new Square(picrossSquare), i, pos);
+                        pos--;
                         picrossSquare = 0;
                     }
                 }
-                x--;
             }
-            board.drawSquare(new Square(picrossSquare),pos,row);
+            board.drawSquare(new Square(picrossSquare), i, pos);
         }
 
-
-        foreach (int column in picrossColumns){
+        foreach (int j in picrossColumns)
+        {
             int pos = -1; //initialise position of picross squares. Must be to the above the minesweeper grid
             int picrossSquare = 0; //initialise length of first maximal consecutive non-nukey cells to 0
-            int y = width-1; // fill in picross squares from bottom to top
 
-            while (y >= 0){
-                if (!(state[column,y].number == -1)){//if a cell is not a mine, set it to ? and increase our count of consecutive non-mines by 1
-                    state[column,y].number = 9;
-                    picrossSquare ++;
-                }else{//otherwise reset count to 0 and move to next picross square position
-                    if (picrossSquare != 0){
-                        board.drawSquare(new Square(picrossSquare),column,pos);
-                        pos --;
+            // fill in picross squares from bottom to top
+            for (int i = height - 1; i >= 0; i--)
+            {
+                if (state[i, j].number != -1)
+                {//if a cell is not a mine, set it to ? and increase our count of consecutive non-mines by 1
+                    state[i, j].number = 9;
+                    picrossSquare++;
+                }
+                else
+                {//otherwise reset count to 0 and move to next picross square position
+                    if (picrossSquare != 0)
+                    {
+                        board.drawSquare(new Square(picrossSquare), pos, j);
+                        pos--;
                         picrossSquare = 0;
                     }
                 }
-                y--;
             }
-            board.drawSquare(new Square(picrossSquare),column,pos);
+            board.drawSquare(new Square(picrossSquare), pos, j);
         }
-
     }
 
-
-
-    private void MakeCells(){
+    private void MakeCells()
+    {
         //for each box in our grid, make a new empty cell
-        for (int x = 0; x < width; x++){
-            for (int y = 0; y < height; y++){
+        for (int i = 0; i < height; i++)
+        {
+            for (int j = 0; j < width; j++)
+            {
                 Cell cell = new Cell();
                 cell.number = 0;
                 cell.revealed = false;
                 cell.flagged = false;
-                state[x,y] = cell;
+                state[i, j] = cell;
             }
         }
     }
 
-
-
-    private int CountMines(int x, int y){
+    private int CountMines(int centerI, int centerJ)
+    {
         int count = 0;
-        for (int i = x-1; i < x+2; i++){//for each cell (x,y), check all 8 cells surrounding it (cell(x-1,y-1) to cell(x+1,y+1))
-            for (int j = y-1; j < y+2; j++){
-                if (i<0 || i>=width || j<0 || j>=height){//avoids checking cells that are out of bounds
+        for (int i = centerI - 1; i < centerI + 2; i++)
+        {//for each cell (i,j), check all 8 cells surrounding it (cell(i-1,j-1) to cell(i+1,j+1))
+            for (int j = centerJ - 1; j < centerJ + 2; j++)
+            {
+                if (i < 0 || i >= height || j < 0 || j >= width)
+                {//avoids checking cells that are out of bounds
                     continue;
                 }
-                if (state[i,j].number == -1){ //increase count if a surrounding cell is a mine
-                    count ++;
+                if (state[i, j].number == -1)
+                { //increase count if a surrounding cell is a mine
+                    count++;
                 }
             }
         }
         return count;
     }
 
-
-
-    private void NumberCells(){
-        for (int x = 0; x < width; x++){//for each cell in the grid, count the mines surrounding it and number it accordingly
-            for (int y = 0; y < height; y++){
-                if (state[x,y].number != -1){
-                    if (state[x,y].number != 9){
-                        state[x,y].number = CountMines(x,y);
-                    }
-
+    private void NumberCells()
+    {
+        for (int i = 0; i < height; i++)
+        {//for each cell in the grid, count the mines surrounding it and number it accordingly
+            for (int j = 0; j < width; j++)
+            {
+                if (state[i, j].number != -1 && state[i, j].number != 9)
+                {
+                    state[i, j].number = CountMines(i, j);
                 }
             }
         }
     }
 
-
     //USER INPUT==========================================================================================
 
-    //private void Update(){ //Mobile commands???
-      //  foreach(Touch touch in Input.touches){
-        //    if (touch.phase == TouchPhase.Began){
-          //  }
-    //}
-
-
-    // Returns true if a right click or a long tap is detected
+    // Returns the position vector if a right click or a long tap is detected
+    // Returns null otherwise
     private Vector3? DetectFlagAction()
     {
-        if (Input.GetMouseButtonDown(1)) return Input.mousePosition;
+        if (Input.GetMouseButtonDown(1))
+            return Input.mousePosition;
         foreach (Touch touch in Input.touches)
         {
             if (touch.phase == TouchPhase.Ended
-                && touch.deltaTime >= LongPressDuration) return touch.position;
+                    && touch.deltaTime >= LongPressDuration)
+                return touch.position;
         }
         return null;
     }
-
 
     // Returns the position vector if a left click or a tap is detected
     // Returns null otherwise
     private Vector3? DetectRevealAction()
     {
-        if (Input.GetMouseButtonDown(0)) return Input.mousePosition;
+        if (Input.GetMouseButtonDown(0))
+            return Input.mousePosition;
         foreach (Touch touch in Input.touches)
         {
             if (touch.phase == TouchPhase.Ended
-                && touch.deltaTime < LongPressDuration) return touch.position;
+                    && touch.deltaTime < LongPressDuration)
+                return touch.position;
         }
         return null;
     }
-
 
     private void Update()
     {
@@ -249,6 +247,7 @@ public class MainGame : MonoBehaviour
                 }
             }
         }
+
         if (DetectRevealAction() is Vector3 revealPos)
         {
             (int i, int j) = board.ScreenToCoord(revealPos);


### PR DESCRIPTION
# Before

The grid coordinaters (i, j) represented the i-th column and the j-th row. This contradicts the Game State Documentation. It also gives the following error when width != height (tested with width=8, height=16).
```
IndexOutOfRangeException: Index was outside the bounds of the array.
MainGame.MakeSquares () (at Assets/Scripts/MainGame.cs:103)
MainGame.NewGame () (at Assets/Scripts/MainGame.cs:37)
MainGame.Start () (at Assets/Scripts/MainGame.cs:26)
```

# After

Now the coordinates (i, j) represent the i-th row and the j-th column. The above error no longer occurs.

I also did some refactoring that does not affect the behavior.