### PR TITLE
Reveal cells adjacent to a clicked empty cell

### DIFF
--- a/Assets/Scripts/MainGame.cs
+++ b/Assets/Scripts/MainGame.cs
@@ -290,6 +290,27 @@ public class MainGame : MonoBehaviour
             score += 1;
             if (score == width * height - mineNum)
                 GameWon();
+            if (state[i, j].number == 0)
+            {
+                RevealCellAround(i, j);
+            }
+        }
+    }
+
+    private void RevealCellAround(int centerI, int centerJ) {
+        for (int i = centerI - 1; i <= centerI + 1; i++)
+        {
+            for (int j = centerJ - 1; j <= centerJ + 1; j++)
+            {
+                if (i < 0 || i >= height || j < 0 || j >= width)
+                {
+                    continue;
+                }
+                if (!state[i, j].revealed)
+                {
+                    RevealCell(i, j);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
# Before
Click on a cell with no adjacent mine (an empty cell) only reveals that cell.

# After 
Click on an empty cell also reveals its adjacent cells as if they were clicked as well.

![image](https://user-images.githubusercontent.com/40788005/229944349-76455938-b608-4db8-a44b-829881362ae0.png)
Figure: clicked on two cells (center, middle right) (#mines reduced)
